### PR TITLE
Fixes #69

### DIFF
--- a/.bluemix/pipeline-TEST.sh
+++ b/.bluemix/pipeline-TEST.sh
@@ -5,8 +5,11 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.2/install.sh | b
 nvm install 6.9.1
 npm install
 if [ -z ${COVERALLS_REPO_TOKEN} ]; then
-  npm run idra
   echo No Coveralls token specified, skipping coveralls.io upload
+
+  npm run idra:coverage
+  npm run idra:publish-coverage
+  npm run idra:publish-unittest
 else
   npm run coverage
 fi

--- a/.bluemix/pipeline-TEST.sh
+++ b/.bluemix/pipeline-TEST.sh
@@ -7,8 +7,13 @@ npm install
 if [ -z ${COVERALLS_REPO_TOKEN} ]; then
   echo No Coveralls token specified, skipping coveralls.io upload
 
+  echo Running DevOps Insights coverage and unit tests
   npm run idra:coverage
+
+  echo Publishing coverage results to DevOps Insights
   npm run idra:publish-coverage
+
+  echo Publishing unit tests to DevOps Insights
   npm run idra:publish-unittest
 else
   npm run coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,10 @@
 .idea
 .project
 .strong-pm
-coverage
 node_modules
 npm-debug.log
 client/vendor
 in-memory-database.json
-coverage
 .coveralls.yml
 out
 server/datasources.local.json
-test/results

--- a/coverage/.gitignore
+++ b/coverage/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "coverage": "istanbul cover _mocha test/*.js --report lcovonly -- -R spec --timeout 300000 && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage/",
     "localcoverage": "istanbul cover _mocha test/*.js --report html -- -R spec --timeout 300000",
     "exportapi": "slc loopback:export-api-def -o spec.yaml",
-    "idra": "istanbul cover --report lcov --report json-summary _mocha -- -R xunit -O output=./test/results/mocha.xml 'test/**/*.js' && idra --publishtestresult --filelocation=./coverage/coverage-summary.json --type=code && idra --publishtestresult --filelocation=./test/results/mocha.xml --type=unittest"
+    "idra:coverage": "istanbul cover --report lcov --report json-summary _mocha -- -R xunit -O output=./test/results/mocha.xml 'test/**/*.js'",
+    "idra:publish-coverage": "idra --publishtestresult --filelocation=./coverage/coverage-summary.json --type=code",
+    "idra:publish-unittest": "idra --publishtestresult --filelocation=./test/results/mocha.xml --type=unittest"
+
   },
   "dependencies": {
     "async": "2.1.4",

--- a/test/results/.gitignore
+++ b/test/results/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
The coverage and tests/results folders were not present, which led to istanbul throwing an ERR. Have added empty dirs with gitignores to commit the actual directories but prevent any locally run coverage/unit tests from being committed.